### PR TITLE
fix: X-axis labels were not centerized according to points or grids in some cases

### DIFF
--- a/src/charting/utils/Utils.ts
+++ b/src/charting/utils/Utils.ts
@@ -524,7 +524,7 @@ export namespace Utils {
             c.restore();
         } else {
             if (anchor.x !== 0 || anchor.y !== 0) {
-                //drawOffsetX -= mDrawTextRectBuffer.width() * anchor.x;
+                drawOffsetX -= mDrawTextRectBuffer.width() * anchor.x;
                 drawOffsetY -= lineHeight * anchor.y;
             }
 


### PR DESCRIPTION
## PR Checklist:
- [x] I have tested this extensively and it does not break any existing behavior.
- [ ] I have added/updated examples and tests for any new behavior.
- [ ] If this is a significant change, an issue has already been created where the problem / solution was discussed: [N/A, or add link to issue here]
       <!-- If you'd like to suggest a significant change, please
            create an issue to discuss those changes and gather
            feedback BEFORE submitting your PR. -->


## PR Description
X-axis labels were not centerized in some cases. This line used to be commented in previous versions but seems to be fixing the problem.
How labels are currently displayed (this is more obvious with long labels):
![Screenshot_2020-10-25-11-36-08](https://user-images.githubusercontent.com/55595100/97103833-c67f7480-16b7-11eb-912d-65519b41f995.png)


With this PR, labels are centerized according to gridline or point position. We just need a confirmation for iOS devices and we are done.