### PR TITLE
fix: Corrected bottom position for x axis line.

### DIFF
--- a/src/charting/renderer/XAxisRenderer.ts
+++ b/src/charting/renderer/XAxisRenderer.ts
@@ -145,7 +145,7 @@ export class XAxisRenderer extends AxisRenderer {
         }
 
         if (axis.getPosition() === XAxisPosition.BOTTOM || axis.getPosition() === XAxisPosition.BOTTOM_INSIDE || axis.getPosition() === XAxisPosition.BOTH_SIDED) {
-            c.drawLine(rect.left, rect.bottom, rect.top, rect.bottom, this.mAxisLinePaint);
+            c.drawLine(rect.left, rect.bottom, rect.right, rect.bottom, this.mAxisLinePaint);
         }
     }
 


### PR DESCRIPTION
## PR Checklist:
- [x] I have tested this extensively and it does not break any existing behavior.
- [ ] I have added/updated examples and tests for any new behavior.
- [ ] If this is a significant change, an issue has already been created where the problem / solution was discussed: [N/A, or add link to issue here]
       <!-- If you'd like to suggest a significant change, please
            create an issue to discuss those changes and gather
            feedback BEFORE submitting your PR. -->


## PR Description
An incorrect value was being set in that case. It's probably a mistake during adaptation or an old MPAndroidChart bug.
Because of this bug, x-axis line was badly aligned in bottom position.