### PR TITLE
Fixed Legend YOffset

### DIFF
--- a/demo/app/examples/LineChart.ts
+++ b/demo/app/examples/LineChart.ts
@@ -2,6 +2,8 @@ import { Color } from '@nativescript/core';
 import { LineChart } from '@nativescript-community/ui-chart/charts';
 import { LineData } from '@nativescript-community/ui-chart/data/LineData';
 import { LineDataSet } from '@nativescript-community/ui-chart/data/LineDataSet';
+import { XAxisPosition } from '@nativescript-community/ui-chart/components/XAxis';
+import { LegendDirection, LegendHorizontalAlignment, LegendVerticalAlignment } from '@nativescript-community/ui-chart/components/Legend';
 
 function getRandomInt(min, max) {
     return Math.floor(Math.random() * (max - min + 1)) + min;
@@ -28,7 +30,7 @@ export function onChartLoaded(args) {
     chart.setDragEnabled(true);
     // chart.setHardwareAccelerationEnabled(true);
 
-    const data = new Array(1000).fill(0).map((v, i) => ({
+    const data = new Array(10).fill(0).map((v, i) => ({
         index: i,
         value: Math.random() * 1,
     }));
@@ -40,6 +42,13 @@ export function onChartLoaded(args) {
 
     // create a data object with the data sets
     const ld = new LineData(sets);
+    let xAxis = chart.getXAxis();
+    xAxis.setPosition(XAxisPosition.BOTTOM);
+    const legend = chart.getLegend();
+    // legend.setDirection(LegendDirection.LEFT_TO_RIGHT);
+    // legend.setHorizontalAlignment(LegendHorizontalAlignment.CENTER);
+    // legend.setVerticalAlignment(LegendVerticalAlignment.TOP)
+    legend.setYOffset(10);
 
     // set data
     chart.setData(ld);

--- a/demo/app/examples/LineChart.ts
+++ b/demo/app/examples/LineChart.ts
@@ -2,8 +2,6 @@ import { Color } from '@nativescript/core';
 import { LineChart } from '@nativescript-community/ui-chart/charts';
 import { LineData } from '@nativescript-community/ui-chart/data/LineData';
 import { LineDataSet } from '@nativescript-community/ui-chart/data/LineDataSet';
-import { XAxisPosition } from '@nativescript-community/ui-chart/components/XAxis';
-import { LegendDirection, LegendHorizontalAlignment, LegendVerticalAlignment } from '@nativescript-community/ui-chart/components/Legend';
 
 function getRandomInt(min, max) {
     return Math.floor(Math.random() * (max - min + 1)) + min;
@@ -30,7 +28,7 @@ export function onChartLoaded(args) {
     chart.setDragEnabled(true);
     // chart.setHardwareAccelerationEnabled(true);
 
-    const data = new Array(10).fill(0).map((v, i) => ({
+    const data = new Array(1000).fill(0).map((v, i) => ({
         index: i,
         value: Math.random() * 1,
     }));
@@ -42,13 +40,6 @@ export function onChartLoaded(args) {
 
     // create a data object with the data sets
     const ld = new LineData(sets);
-    let xAxis = chart.getXAxis();
-    xAxis.setPosition(XAxisPosition.BOTTOM);
-    const legend = chart.getLegend();
-    // legend.setDirection(LegendDirection.LEFT_TO_RIGHT);
-    // legend.setHorizontalAlignment(LegendHorizontalAlignment.CENTER);
-    // legend.setVerticalAlignment(LegendVerticalAlignment.TOP)
-    legend.setYOffset(10);
 
     // set data
     chart.setData(ld);

--- a/src/charting/components/Legend.ts
+++ b/src/charting/components/Legend.ts
@@ -148,7 +148,7 @@ export class Legend extends ComponentBase {
         super();
         this.mTextSize = 10;
         this.mXOffset = 5;
-        this.mYOffset = 3;
+        this.mYOffset = 5;
         if (entries) {
             this.mEntries = entries;
         }

--- a/src/charting/renderer/LegendRenderer.ts
+++ b/src/charting/renderer/LegendRenderer.ts
@@ -99,8 +99,7 @@ export class LegendRenderer extends Renderer {
 
                     for (let j = 0; j < clrs.length && j < entryCount; j++) {
                         const label = pds.getEntryForIndex(j).label;
-                        if (label == null)
-                        {
+                        if (label == null) {
                             continue;
                         }
 
@@ -240,7 +239,7 @@ export class LegendRenderer extends Renderer {
                         break;
 
                     case LegendVerticalAlignment.BOTTOM:
-                        posY = this.mViewPortHandler.getChartHeight() - yoffset - this.mLegend.mNeededHeight;
+                        posY = this.mViewPortHandler.getChartHeight() - this.mLegend.mNeededHeight;
                         break;
 
                     case LegendVerticalAlignment.CENTER:


### PR DESCRIPTION
## PR Description
This fixes a bug where the legend YOffset was being added and then subtracted preventing it from working. The yoffset is added to the mNeededHeight property on the Legend so it doesn't need to be subtracted on the LegendRenderer, or it has no effect.
