### PR TITLE
Fix #35: Fix exception when constructing Tween object

### DIFF
--- a/src/charting/jobs/AnimatedViewPortJob.ts
+++ b/src/charting/jobs/AnimatedViewPortJob.ts
@@ -1,4 +1,5 @@
 import { Tween } from '@tweenjs/tween.js';
+import TWEEN from '@nativescript-community/tween';
 import { BarLineChartBase } from '../charts/BarLineChartBase';
 import { Transformer } from '../utils/Transformer';
 import { ViewPortHandler } from '../utils/ViewPortHandler';
@@ -30,7 +31,7 @@ export abstract class AnimatedViewPortJob extends ViewPortJob implements Animato
     }
 
     createAnimator(duration) {
-        this.animator = new Tween<any>({ value: 0 })
+        this.animator = new TWEEN.Tween<any>({ value: 0 })
             .to({ value: 1 }, duration)
             .onStop(() => this.onAnimationCancel(this.animator))
             .onComplete(() => this.onAnimationEnd(this.animator))


### PR DESCRIPTION
## PR Checklist:
- [x] I have tested this extensively and it does not break any existing behavior.
- [ ] (N/A) I have added/updated examples and tests for any new behavior.
- [ ] (N/A) If this is a significant change, an issue has already been created where the problem / solution was discussed: [N/A, or add link to issue here]
       <!-- If you'd like to suggest a significant change, please
            create an issue to discuss those changes and gather
            feedback BEFORE submitting your PR. -->


## PR Description
This PR resolves #35 where constructing a `Tween` object failed with the exception listed in the issue. This fix allows the `chart.moveViewToAnimated(...)` to function as expected, where previously no animation occurs.

<!-- What does this add/ remove/ fix/ change? -->

<!-- WHY should this PR be merged into the main library? -->
@farfromrefug I tested this locally in my project by building the plugin with `npm run build`, then installing the locally built plugin in my project. The original import is still in place since it is used for types in the rest of the TS file, but I can modify it if you'd prefer otherwise.
