### PR TITLE
changed internalvalue const to method calls

### DIFF
--- a/src/charting/data/DataSet.ts
+++ b/src/charting/data/DataSet.ts
@@ -209,6 +209,7 @@ export abstract class DataSet<T extends Entry> extends BaseDataSet<T> {
     public clear() {
         this.mValues = [];
         this.notifyDataSetChanged();
+        this.updateGetEntryForIndex();
     }
 
     public addEntry(e: T) {


### PR DESCRIPTION
## PR Checklist:
- [x] I have tested this extensively and it does not break any existing behavior.
- [ ] I have added/updated examples and tests for any new behavior.
- [ ] If this is a significant change, an issue has already been created where the problem / solution was discussed: [N/A, or add link to issue here]
       <!-- If you'd like to suggest a significant change, please
            create an issue to discuss those changes and gather
            feedback BEFORE submitting your PR. -->


## PR Description
<!-- Describe Your PR Here! -->
Right now, if you add some dataset to a chart, and then you clear the chart and insert some data again, you will get this error when highlting an entry:

TypeError: Cannot read property 'x' of undefined
at LineDataSet.BaseDataSet.getEntryXValue (file: node_modules/@nativescript-community/ui-chart/data/BaseDataSet.js:37:0)
at ChartHighlighter.buildHighlights (file: node_modules/@nativescript-community/ui-chart/highlight/ChartHighlighter.js:65:0)
at ChartHighlighter.getHighlightsAtXValue (file: node_modules/@nativescript-community/ui-chart/highlight/ChartHighlighter.js:54:0)
at ChartHighlighter.getHighlightForX (file: node_modules/@nativescript-community/ui-chart/highlight/ChartHighlighter.js:19:0)
at ChartHighlighter.getHighlight (file: node_modules/@nativescript-community/ui-chart/highlight/ChartHighlighter.js:11:0)
at GlucoseChart.getHighlightByTouchPoint (file: node_modules/@nativescript-community/ui-chart/charts/Chart.js:210:0)
at BarLineChartTouchListener.onTapGesture (file: node_modules/@nativescript-community/ui-chart/listener/BarLineChartTouchListener.js:407:0)
at Function._handleEvent (file: node_modules/@nativescript/core/data/observable/index.js:230:0)
at Handler.notify (file: node_modules/@nativescript/core/data/observable/index.js:216:0)
at HandlerDelegate.gestureHandlerDidChangeStatePrevStateExtraDataView (file: node_modules/@nativescript-community/gesturehandler/gesturehandler.ios.js:107:0)

This is happening because the `getEntryForIndex` method is returning an undefined entry. Looking through the code I found out that the `getEntryForIndex` method gets updated: 


```
updateGetEntryForIndex() {
        const internalValues = this.getInternalValues();
        if (internalValues instanceof ObservableArray) {
            this.getEntryForIndex = function (index) {
                return internalValues.getItem(index);
            };
        }
        else {
            this.getEntryForIndex = function (index) {
                return internalValues[index];
            };
        }
}
```



but the internalValues is declared on the `updateGetEntryForIndex` method, not on the `getEntryForIndex` update, this is causing `internalValues` to stay empty and thus returning undefined when trying to get the entry. Fixed by simply making the call inside the updated methods instead.


What does this add/ remove/ fix/ change? 
removes a const to add 2 method calls.

 WHY should this PR be merged into the main library? 
Solves a possible crash.
