### PR TITLE
added support for setting and getting clipHighlightToContent

### DIFF
--- a/demo_vue/app/examples/Basic.vue
+++ b/demo_vue/app/examples/Basic.vue
@@ -49,7 +49,7 @@ export default Vue.extend({
         onChartLoaded() {
             const chart = this.$refs.chart['nativeView'] as LineChart;
             chart.drawFrameRate = true;
-
+            // chart.setClipHighlightToContent(true);
             // chart.backgroundColor = 'white';
             // disable description text
             // chart.getDescription().setEnabled(false);

--- a/src/charting/charts/BarLineChartBase.ts
+++ b/src/charting/charts/BarLineChartBase.ts
@@ -1268,6 +1268,14 @@ export abstract class BarLineChartBase<U extends Entry, D extends IBarLineScatte
      */
     clipHighlightToContent = true;
 
+    public setClipHighlightToContent(enabled){
+        this.clipHighlightToContent = enabled;
+    }
+
+    public isClipHighlightToContentEnabled(){
+        return this.clipHighlightToContent;
+    }
+
     public setDrawHighlight(enabled) {
         this.mDrawHighlight = enabled;
     }


### PR DESCRIPTION
## PR Checklist:
- [ x] I have tested this extensively and it does not break any existing behavior.
- [ x] I have added/updated examples and tests for any new behavior.
- [ ] If this is a significant change, an issue has already been created where the problem / solution was discussed: [N/A, or add link to issue here]
       <!-- If you'd like to suggest a significant change, please
            create an issue to discuss those changes and gather
            feedback BEFORE submitting your PR. -->


## PR Description
<!-- Describe Your PR Here! -->
Added support for getting and setting clipHighlightToContent.

<!-- What does this add/ remove/ fix/ change? -->
Added function setClipHighlightToContent and isClipHighlightToContentEnabled (same style as as setting the clipping of data and values) in order to allow the highlight to be drawn outside of the content area without bleeding out graphs.

<!-- WHY should this PR be merged into the main library? -->
As the variable was already present but lacked the functions to set / get this seemed like a "missing" feature
