### PR TITLE
fix: getDataSetByHighlight in CombinedData

### DIFF
--- a/src/charting/data/CombinedData.ts
+++ b/src/charting/data/CombinedData.ts
@@ -164,7 +164,7 @@ export class CombinedData extends BarLineScatterCandleBubbleData<Entry, BarLineS
     public getDataSetByHighlight(highlight: Highlight) {
         if (highlight.dataIndex >= this.getAllData().length) return null;
 
-        const data = this.getDataByIndex(highlight.dataSetIndex);
+        const data = this.getDataByIndex(highlight.dataIndex);
 
         if (highlight.dataSetIndex >= data.getDataSetCount()) return null;
 


### PR DESCRIPTION
## PR Checklist:
- [x] I have tested this extensively and it does not break any existing behavior.
- [x] I have added/updated examples and tests for any new behavior.
- [x] If this is a significant change, an issue has already been created where the problem / solution was discussed: N/A

## PR Description
There is an issue with `getDataSetByHighlight` implementation for `CombinedData` which leads to improper behavior and exception afterwards