### PR TITLE
fix(ios): Use different gesture tags when there is multiple pie/radar charts

### DIFF
--- a/src/charting/charts/Chart.ts
+++ b/src/charting/charts/Chart.ts
@@ -1,4 +1,4 @@
-import { PanGestureHandlerOptions, PinchGestureHandlerOptions, TapGestureHandlerOptions } from '@nativescript-community/gesturehandler';
+import { PanGestureHandlerOptions, PinchGestureHandlerOptions, RotationGestureHandlerOptions, TapGestureHandlerOptions } from '@nativescript-community/gesturehandler';
 import { Align, Canvas, CanvasView, Paint } from '@nativescript-community/ui-canvas';
 import { EventData, Utils as NUtils, Trace } from '@nativescript/core';
 import { ChartAnimator, EasingFunction } from '../animation/ChartAnimator';
@@ -215,6 +215,7 @@ export abstract class Chart<U extends Entry, D extends IDataSet<U>, T extends Ch
     public tapGestureOptions: TapGestureHandlerOptions & { gestureTag?: number };
     public doubleTapGestureOptions: TapGestureHandlerOptions & { gestureTag?: number };
     public pinchGestureOptions: PinchGestureHandlerOptions & { gestureTag?: number };
+    public rotationGestureOptions: RotationGestureHandlerOptions & { gestureTag?: number };
 
     /**
      * Sets a new data object for the chart. The data object contains all values

--- a/src/charting/listener/PieRadarChartTouchListener.ts
+++ b/src/charting/listener/PieRadarChartTouchListener.ts
@@ -5,6 +5,9 @@ import { Utils } from '../utils/Utils';
 import { ChartGesture, ChartTouchListener } from './ChartTouchListener';
 import { GestureHandlerStateEvent, GestureState, GestureStateEventData, HandlerType, Manager, RotationGestureHandler, TapGestureHandler } from '@nativescript-community/gesturehandler';
 
+let TAP_HANDLER_TAG = 11232000;
+let ROTATION_HANDLER_TAG = 11231000;
+
 /**
  * TouchListener for Pie- and RadarChart with handles all
  * touch interaction.
@@ -20,14 +23,26 @@ export class PieRadarChartTouchListener extends ChartTouchListener<PieRadarChart
      *
      * @param chart instance of the chart
      */
+    TAP_HANDLER_TAG;
+    ROTATION_HANDLER_TAG;
     constructor(chart: PieRadarChartBase<any, any, any>) {
         super(chart);
+        this.TAP_HANDLER_TAG = TAP_HANDLER_TAG++;
+        this.ROTATION_HANDLER_TAG = ROTATION_HANDLER_TAG++;
+    }
+
+    getTapGestureOptions() {
+        return { gestureTag: this.TAP_HANDLER_TAG, ...(this.mChart.tapGestureOptions || {}) };
+    }
+    getRotationGestureOptions() {
+        return { gestureTag: this.ROTATION_HANDLER_TAG, ...(this.mChart.rotationGestureOptions || {}) };
     }
 
     getOrCreateRotationGestureHandler() {
         if (!this.rotationGestureHandler) {
             const manager = Manager.getInstance();
-            this.rotationGestureHandler = manager.createGestureHandler(HandlerType.ROTATION, 11231, {}).on(GestureHandlerStateEvent, this.onRotationGesture, this);
+            const options = this.getRotationGestureOptions();
+            this.rotationGestureHandler = manager.createGestureHandler(HandlerType.ROTATION, options.gestureTag, {}).on(GestureHandlerStateEvent, this.onRotationGesture, this);
         }
         return this.rotationGestureHandler;
     }
@@ -35,7 +50,8 @@ export class PieRadarChartTouchListener extends ChartTouchListener<PieRadarChart
     getOrCreateTapGestureHandler() {
         if (!this.tapGestureHandler) {
             const manager = Manager.getInstance();
-            this.tapGestureHandler = manager.createGestureHandler(HandlerType.TAP, 11232, {}).on(GestureHandlerStateEvent, this.onTapGesture, this);
+            const options = this.getTapGestureOptions();
+            this.tapGestureHandler = manager.createGestureHandler(HandlerType.TAP, options.gestureTag, {}).on(GestureHandlerStateEvent, this.onTapGesture, this);
         }
         return this.tapGestureHandler;
     }


### PR DESCRIPTION
## PR Checklist:
- [x] I have tested this extensively and it does not break any existing behavior.
- [ ] I have added/updated examples and tests for any new behavior.
- [ ] If this is a significant change, an issue has already been created where the problem / solution was discussed: [N/A, or add link to issue here]
       <!-- If you'd like to suggest a significant change, please
            create an issue to discuss those changes and gather
            feedback BEFORE submitting your PR. -->


## PR Description
<!-- Describe Your PR Here! -->
When there is more than one pie (or radar) chart on the same page on iOS and the latest added pie chart slices get tapped the first pie chart's tap gesture handler gets triggered instead of the one tapped. And when the first pie chart's slices get tapped nothing happens. This commit aims to fix this issue. (bar/line charts already have the logic that is added with this commit for pie and radar charts)

<!-- What does this add/ remove/ fix/ change? -->

<!-- WHY should this PR be merged into the main library? -->
