### PR TITLE
fix: correct multi-color fill shader stops

### DIFF
--- a/src/ui-chart/renderer/LineChartRenderer.ts
+++ b/src/ui-chart/renderer/LineChartRenderer.ts
@@ -3,7 +3,6 @@ import { Canvas, Direction, FillType, LinearGradient, Matrix, Paint, Path, Style
 import { Color, ImageSource, Screen, profile } from '@nativescript/core';
 import { ChartAnimator } from '../animation/ChartAnimator';
 import { LineChart } from '..';
-import { Rounding } from '../data/DataSet';
 import { LineDataSet, Mode } from '../data/LineDataSet';
 import { Highlight } from '../highlight/Highlight';
 import { ILineDataSet } from '../interfaces/datasets/ILineDataSet';
@@ -467,72 +466,85 @@ export class LineChartRenderer extends LineRadarRenderer {
         }
     }
 
-    getMultiColorsShader(colors: { color: string | Color; [k: string]: any }[], points, trans: Transformer, dataSet: LineDataSet) {
+    /**
+     * Hard edged gradient over the content rect, one band per color. Each color carries the index of
+     * the entry it starts at, in `dataSet.xProperty` or in `index`.
+     *
+     * The pixel of a stop is derived from the entry's x **value** through the transformer rather than
+     * from the point buffer: that buffer holds 2 floats per entry in LINEAR/STEPPED mode but 6 in
+     * either bezier mode (two control points and the anchor), so indexing it with a stride of 2 put
+     * every stop at roughly a third of its real position, and the error moved with the pan. Going
+     * through the transformer is mode agnostic, and filtering agnostic too: decimation changes which
+     * entries exist, not where a given x value lands on screen.
+     *
+     * @param alpha optional 0-255 alpha applied to every stop, for the fill pass
+     */
+    getMultiColorsShader(colors: { color: string | Color; [k: string]: any }[], trans: Transformer, dataSet: LineDataSet, alpha?: number) {
         const nbColors = colors.length;
-        const xKey = dataSet.xProperty;
-        if (nbColors > 0) {
-            trans.pointValuesToPixel(points);
-            const shaderColors = [];
-            const positions = [];
-            const firstIndex = Math.max(0, this.mXBounds.min);
-            const range = this.mXBounds.range;
-            const lastIndex = firstIndex + range;
-            const width = this.mViewPortHandler.chartWidth;
-            const chartRect = this.mViewPortHandler.chartRect;
-            let lastColor;
-
-            const gradientDelta = 0;
-            const posDelta = gradientDelta / width;
-            for (let index = 0; index < nbColors; index++) {
-                const color = colors[index] as { color: string | Color; [k: string]: any };
-                let colorIndex = color[xKey || 'index'] as number;
-                // if filtered we need to get the real index
-                if (dataSet.filtered) {
-                    dataSet.ignoreFiltered = true;
-                    const entry = dataSet.getEntryForIndex(colorIndex);
-                    dataSet.ignoreFiltered = false;
-                    if (entry) {
-                        colorIndex = dataSet.getEntryIndexForXValue(dataSet.getEntryXValue(entry, colorIndex), NaN, Rounding.CLOSEST);
-                    }
-                }
-                if (colorIndex < firstIndex) {
-                    lastColor = color.color;
-                    continue;
-                }
-                if (colorIndex > lastIndex) {
-                    if (shaderColors.length === 0) {
-                        shaderColors.push(lastColor);
-                        positions.push(0);
-                        shaderColors.push(lastColor);
-                        positions.push(1);
-                    }
-                    break;
-                }
-                const posX = Math.floor(points[(colorIndex - firstIndex) * 2]);
-                const pos = (posX - chartRect.left) / width;
-                if (lastColor) {
-                    if (shaderColors.length === 0) {
-                        shaderColors.push(lastColor);
-                        positions.push(0);
-                    }
-                    shaderColors.push(lastColor);
-                    positions.push(pos - posDelta);
-                }
-                shaderColors.push(color.color);
-                positions.push(pos + posDelta);
-                lastColor = color.color;
-            }
-            if (shaderColors.length === 0) {
-                shaderColors.push(colors[0].color);
-                positions.push(0);
-            }
-            if (shaderColors.length === 1) {
-                shaderColors.push(colors[0].color);
-                positions.push(1);
-            }
-            return new LinearGradient(0, 0, width, 0, shaderColors, positions, TileMode.CLAMP);
+        if (nbColors === 0) {
+            return null;
         }
-        return null;
+        const xKey = dataSet.xProperty;
+        const contentRect = this.mViewPortHandler.contentRect;
+        const width = contentRect.width();
+        if (width <= 0) {
+            return null;
+        }
+        const withAlpha = (color: string | Color) => {
+            if (alpha === undefined || alpha >= 255) {
+                return color;
+            }
+            const actual = color instanceof Color ? color : new Color(color);
+            return new Color(Math.round((alpha * actual.a) / 255), actual.r, actual.g, actual.b);
+        };
+
+        const shaderColors = [];
+        const positions = [];
+        let currentColor;
+        let lastPosition = 0;
+        // the stops index the unfiltered values, whatever decimation is currently applied
+        const wasIgnoringFiltered = dataSet.ignoreFiltered;
+        dataSet.ignoreFiltered = true;
+        for (let index = 0; index < nbColors; index++) {
+            const color = colors[index];
+            const colorIndex = color[xKey || 'index'] as number;
+            const entry = dataSet.getEntryForIndex(colorIndex);
+            if (!entry) {
+                continue;
+            }
+            const posX = trans.getPixelForValues(dataSet.getEntryXValue(entry, colorIndex), 0).x;
+            // a stop outside the viewport still matters: clamped, it is the color CLAMP extends past
+            // that edge. Unclamped it would be an out of range gradient stop, which both backends
+            // render as garbage - that was the second half of the "colors jump when panning" bug
+            const position = Math.max(Math.min((posX - contentRect.left) / width, 1), 0);
+            currentColor = withAlpha(color.color);
+            if (shaderColors.length === 0) {
+                // whatever its real position, the first stop anchors the gradient at the left edge
+                shaderColors.push(currentColor);
+                positions.push(0);
+                continue;
+            }
+            if (position <= lastPosition) {
+                // collapsed onto the previous stop, ie clamped or under a pixel wide: it takes over
+                shaderColors[shaderColors.length - 1] = currentColor;
+                continue;
+            }
+            // close the running band and open the new one on the same position, for a hard edge
+            shaderColors.push(shaderColors[shaderColors.length - 1]);
+            positions.push(position);
+            shaderColors.push(currentColor);
+            positions.push(position);
+            lastPosition = position;
+        }
+        dataSet.ignoreFiltered = wasIgnoringFiltered;
+        if (shaderColors.length === 0) {
+            return null;
+        }
+        if (shaderColors.length === 1) {
+            shaderColors.push(currentColor);
+            positions.push(1);
+        }
+        return new LinearGradient(contentRect.left, 0, contentRect.right, 0, shaderColors, positions, TileMode.CLAMP);
     }
 
     lastLinePath: Path;
@@ -573,8 +585,7 @@ export class LineChartRenderer extends LineRadarRenderer {
         const renderPaint = this.renderPaint;
         let paintColorsShader;
         if (nbColors > 1) {
-            // TODO: we transforms points in there. Could be dangerous if used after
-            paintColorsShader = this.getMultiColorsShader(colors as any, points, trans, dataSet);
+            paintColorsShader = this.getMultiColorsShader(colors as any, trans, dataSet);
         }
 
         let oldShader;
@@ -582,7 +593,10 @@ export class LineChartRenderer extends LineRadarRenderer {
             const useColorsForFill = dataSet.useColorsForFill;
             if (paintColorsShader && useColorsForFill) {
                 oldShader = renderPaint.getShader();
-                renderPaint.setShader(paintColorsShader);
+                // the paint color is ignored once a shader is set, so the fill alpha has to be baked
+                // into the stops. Without it a multi colored fill draws opaque while a plain one
+                // honours fillAlpha
+                renderPaint.setShader(dataSet.fillAlpha >= 255 ? paintColorsShader : this.getMultiColorsShader(colors as any, trans, dataSet, dataSet.fillAlpha));
             }
             const fillPath = this.fillPath;
             fillPath.reset();
@@ -594,10 +608,20 @@ export class LineChartRenderer extends LineRadarRenderer {
             const drawFill = () => {
                 this.drawFill(c, dataSet, fillPath, trans, minEntryValue, maxEntryValue);
             };
+            // the fill is painted through clipPath + drawPaint, which floods the whole clip region.
+            // Keep it inside the plot area whatever the platform does with the outer clip
+            const clipToContent = this.mChart.clipDataToContent;
+            const clipSave = clipToContent ? c.save() : 0;
+            if (clipToContent) {
+                c.clipRect(this.mViewPortHandler.contentRect);
+            }
             if (customRender?.drawFill) {
                 customRender.drawFill(c, dataSet, fillPath, trans, minEntryValue, maxEntryValue, drawFill);
             } else {
                 drawFill();
+            }
+            if (clipToContent) {
+                c.restoreToCount(clipSave);
             }
             this.lastLinePath = linePath;
             if (paintColorsShader && useColorsForFill) {


### PR DESCRIPTION
## PR Checklist:
- [ ] I have tested this extensively and it does not break any existing behavior.
- [ ] I have added/updated examples and tests for any new behavior.
- [x] If this is a significant change, an issue has already been created where the problem / solution was discussed: N/A — self contained rendering fix

## PR Description

`getMultiColorsShader` produced wrong gradient stops for a `LineDataSet` with a `colors` array, and the colors visibly shifted while panning or zooming. Found while colouring an elevation profile by slope in [Alpi Maps](https://github.com/Akylas/alpimaps).

### Wrong stride for the bezier modes

The stops were positioned by indexing the point buffer:

```ts
const posX = Math.floor(points[(colorIndex - firstIndex) * 2]);
```

Two floats per entry only holds for `Mode.LINEAR` and `Mode.STEPPED`. `generateCubicPath` and `generateHorizontalBezierPath` emit **six** floats per entry — two control points plus the anchor — so in either bezier mode every stop landed at roughly a third of its real x. The buffer starts at the first *visible* entry, so the error moved with `mXBounds.min`: that is the "colors jump when you pan" symptom.

The fix takes the pixel from the entry's x **value** through the transformer:

```ts
const posX = trans.getPixelForValues(dataSet.getEntryXValue(entry, colorIndex), 0).x;
```

That is independent of the draw mode, and of filtering: decimation changes which entries exist, not where a given x value lands on screen. So the `if (dataSet.filtered)` index remap goes away — it was re-running against a different LTTB set at every zoom step, since `maxFilterNumber` scales with `scaleX`.

It also drops the `trans.pointValuesToPixel(points)` call, which mutated the shared `mLineBuffer` in place (the `// TODO: ... Could be dangerous if used after` comment above it).

### Out of range stops

Positions were never clamped. `mXBounds` covers one entry past each edge, so stops went negative and above 1 — not a valid stop list for either backend (iOS clamps them in `LinearGradient.gradient` but keeps the ordering, Android renders it as garbage). Stops are now clamped into `[0, 1]` and kept monotonic, with collapsed ones overriding rather than duplicating, and the gradient is built over the content rect instead of the whole canvas.

### Fill containment and alpha

Two smaller things on the same path:

- The fill is painted through `clipPath` + `drawPaint`, which floods the whole clip region, so it is now explicitly clipped to `contentRect` when the chart has `clipDataToContent`.
- The paint color is ignored once a shader is set, so a `useColorsForFill` dataset drew fully opaque while the plain fill honoured `fillAlpha`. `fillAlpha` is now baked into the stops for the fill pass.

### Compatibility

The public contract is unchanged — stops are still `{ [xProperty|'index']: entryIndex, color }`. A `colors` array of plain strings (no per-stop index) now yields no shader instead of a bogus single-color one, so the dataset's own `color` is used; that case was already meaningless since `color.color` was `undefined`.

## Verification

- `tsc --build` on `packages/ui-chart` is clean; `eslint` reports only a pre-existing warning on untouched code.
- Verified on device in a real app (Android + iOS): grade colors on an elevation profile are now stable through pinch and pan, and identical zoomed in and zoomed out.
- Not covered by an automated test — the repo has no test runner for the renderers, and `release.yml` is the only workflow. A reviewer should exercise a `LineDataSet` in `CUBIC_BEZIER` with `useColorsForFill` and several color stops, then zoom and pan.